### PR TITLE
Patch window title for void warranties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ Thumbs.db
 
 .idea
 moc_predefs.h
+
+# Nix
+# --------
+/result

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,9 @@
+{ stdenv, lib, qmake, qt5, wrapQtAppsHook }: 
+
+stdenv.mkDerivation rec {
+  pname = "tab-ui";
+  version = "1.0";
+  src = ./.;
+  buildInputs = [ qt5.full ];
+  nativeBuildInputs = [ qmake wrapQtAppsHook ]; 
+}

--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,0 @@
-{ stdenv, lib, qmake, qt5, wrapQtAppsHook }: 
-
-stdenv.mkDerivation rec {
-  pname = "tab-ui";
-  version = "1.0";
-  src = ./.;
-  buildInputs = [ qt5.full ];
-  nativeBuildInputs = [ qmake wrapQtAppsHook ]; 
-}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1734323986,
+        "narHash": "sha256-m/lh6hYMIWDYHCAsn81CDAiXoT3gmxXI9J987W5tZrE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "394571358ce82dff7411395829aa6a3aad45b907",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,10 @@
           qtquickcontrols2
           wrapQtAppsHook
         ];
+
+        patches = [
+          ./patches/0001-main.qml-change-window-title-for-voidwarranties.patch
+        ];
       };
     });
   };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,77 @@
+{
+  description = "Flake for the bar tab frontend application (tab-ui)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  } @ inputs: let
+    # This list of architectures provides the supported systems to the wrapper function below.
+    # It basically defines which architectures can build and run the tab-ui application.
+    supportedSystems = [
+      "aarch64-darwin"
+      "x86_64-linux"
+    ];
+
+    # This helper function is used to make the flake outputs below more DRY. It looks a bit intimidating but that's
+    # mostly because of the functional programming nature of Nix. I recommend reading
+    # [Nix language basics](https://nix.dev/tutorials/nix-language.html) and search online for resources about
+    # functional programming paradigms.
+    #
+    # Basically this function makes it so that instead of declaring outputs for every architecture as the flake schema
+    # expects, e.g.:
+    #
+    # packages = {
+    #   "x86_64-linux" = {
+    #     ...
+    #   };
+    #   "aarch64-darwin" = {
+    #     ...
+    #   };
+    # };
+    #
+    # we can define each output below (package, formatter, ...) once for all the architectures / systems.
+    #
+    # It is a simplified version of [flake-utils](https://github.com/numtide/flake-utils). Check it out to learn more!
+    #
+    forAllSystems = function:
+      nixpkgs.lib.genAttrs supportedSystems (system:
+        function (import nixpkgs {
+          inherit system;
+        }));
+  in {
+    formatter = forAllSystems (pkgs: pkgs.alejandra);
+
+    packages = forAllSystems (pkgs: {
+      # There's only one package defined in this flake, so let's make that the default one:
+      default = pkgs.stdenv.mkDerivation rec {
+        pname = "tab-ui";
+
+        # tab-ui does not have versioned releases. To still keep track of some sort of version (a Nix package requires
+        # it and it's also convenient for debugging) and not having to make up something arbitrary like "1.0", we'll
+        # use the Nix builtin substring function to extract the first 7 characters of the git commit hash that the
+        # build of this package is based on and use that as the version indicator.
+        # To avoid duplication or creating extra variables through let bindings, we'll make the attribute set passed to
+        # the mkDerivation function above recursive by adding the `rec` keyword. This allows us to reference the
+        # revision attribute in the fetchgit function below through `src.rev`.
+        version = builtins.substring 0 7 src.rev;
+
+        src = pkgs.fetchgit {
+          url = "https://github.com/voidwarranties/tab-ui.git";
+          rev = "90c0d413625e53826605c5b92fcc02e5b4a8b736";
+          hash = "sha256-uQ/BIEYArVs0KIwfDNQbqxrTSbwZ6NIgW4KMwz7xSHk=";
+          fetchSubmodules = true;
+        };
+
+        buildInputs = with pkgs.qt5; [
+          qmake
+          qtquickcontrols2
+          wrapQtAppsHook
+        ];
+      };
+    });
+  };
+}

--- a/patches/0001-main.qml-change-window-title-for-voidwarranties.patch
+++ b/patches/0001-main.qml-change-window-title-for-voidwarranties.patch
@@ -1,0 +1,13 @@
+diff --git a/main.qml b/main.qml
+index dcb56a1..7fc4ee0 100644
+--- a/main.qml
++++ b/main.qml
+@@ -13,7 +13,7 @@ Window {
+     width: 640
+     height: 480
+     visibility: Window.Maximized
+-    title: qsTr("Hackerspace.gent tab-ui")
++    title: qsTr("VoidWarranties Barputer UI")
+     color: "black"
+ 
+     property int fontSize: 16


### PR DESCRIPTION
This PR adds a patch to the tab-ui source code changing the window title from "Hackerspace.gent ..." to "VoidWarranties ...". The reasoning for doing it through a patch that gets applied during package build is as follows:

The upstream tab-ui project does not support setting the window title through configuration. The only way to change it is by modifying the source code. Although we maintain our own fork of tab-ui with some new features already added, it feels more appropriate to not explicitly replace Hackerspace Gent strings with our own. This is where the patch comes in. It is applied to the source code right before Nix builds the package.
Conversely, disabling the patch and thus preventing the window title to change is as easy as commenting out the line where the patch gets applied. To avoid cluttering the root of the project, patches go into the newly created `patches` directory.